### PR TITLE
chore: remove outdated cache control rules from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -80,15 +80,6 @@
           "value": "/"
         }
       ]
-    },
-    {
-      "source": "/(.*.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot))",
-      "headers": [
-        {
-          "key": "Cache-Control",
-          "value": "public, max-age=31536000, immutable"
-        }
-      ]
     }
   ],
   "redirects": [


### PR DESCRIPTION
- Eliminated unnecessary cache control rules for static assets in vercel.json to streamline configuration.
- This change helps maintain a cleaner setup and focuses on essential caching strategies.